### PR TITLE
Lower min character threshold to trigger search

### DIFF
--- a/src/components/search.js
+++ b/src/components/search.js
@@ -12,7 +12,7 @@ import {
 import './algolia.css'
 
 // Min number of characters needed to trigger search results
-const MIN_CHAR_COUNT = 4
+const MIN_CHAR_COUNT = 0
 
 const Result = ({ hit }) => (
   <a style={{ marginTop: '10px' }} href={hit.slug}>


### PR DESCRIPTION
Right now a user must enter at least 4 characters before the search is triggered and results are displayed. This is confusing, because at first it seems like the search bar is broken. I'm lowering the min characters to zero so the search is triggered as you start typing. 